### PR TITLE
Revert "chore(deps): update helm release rabbitmq to 12.15.x (ci)"

### DIFF
--- a/knightcrawler/helmrelease-rabbitmq.yaml
+++ b/knightcrawler/helmrelease-rabbitmq.yaml
@@ -7,7 +7,7 @@ spec:
   chart:
     spec:
       chart: rabbitmq
-      version: 12.15.x
+      version: 12.12.x
       sourceRef:
         kind: HelmRepository
         name: bitnami


### PR DESCRIPTION
Reverts geek-cookbook/elf-infra#1000 - may have broken rabbitmq for knightcrawler!